### PR TITLE
Fix mobile menu with sliding page animation

### DIFF
--- a/app/(main-route)/events/EventCard.tsx
+++ b/app/(main-route)/events/EventCard.tsx
@@ -5,8 +5,8 @@ import Link from "next/link";
 
 export default function EventCard(props: { name: string; event: Event }) {
   return (
-    <div className="flex flex-wrap m-auto w-5/6 justify-center gap-8">
-      <div className="w-75 p-2 relative h-55">
+    <div className="flex flex-col md:flex-row flex-wrap m-auto w-5/6 justify-center gap-8">
+      <div className="w-full md:w-75 p-2 relative h-55">
         <Link href={`/events/${props.name}`}>
           <Image
             fill
@@ -27,7 +27,7 @@ export default function EventCard(props: { name: string; event: Event }) {
           </div>
         </Link>
       </div>
-      <div className="w-1/2">
+      <div className="w-full md:w-1/2">
         <PageContent
           pageLayout={[
             {

--- a/app/(main-route)/layout.tsx
+++ b/app/(main-route)/layout.tsx
@@ -1,5 +1,7 @@
 import Footer from "@/components/footer/Footer";
 import Header from "@/components/header/header";
+import { MobileMenuProvider } from "@/components/header/MobileMenuContext";
+import MobileMenuDrawer from "@/components/header/MobileMenuDrawer";
 
 export default function MainRoutes({
   children,
@@ -7,10 +9,13 @@ export default function MainRoutes({
   children: React.ReactNode;
 }) {
   return (
-    <>
-      <Header></Header>
-      {children} {/* Page content renders here */}
-      <Footer></Footer>
-    </>
+    <MobileMenuProvider>
+      <MobileMenuDrawer />
+      <div id="page-wrapper">
+        <Header></Header>
+        {children} {/* Page content renders here */}
+        <Footer></Footer>
+      </div>
+    </MobileMenuProvider>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -76,7 +76,6 @@ body {
   max-width: 100vw;
 }
 
-
 :root {
   --background: #ffffff;
   --foreground: #171717;

--- a/app/globals.css
+++ b/app/globals.css
@@ -76,18 +76,6 @@ body {
   max-width: 100vw;
 }
 
-#page-wrapper {
-  transition: transform 0.3s ease-in-out;
-  background-color: white;
-  position: relative;
-}
-
-/* Mobile menu slide effect */
-@media (max-width: 767px) {
-  body.mobile-menu-open #page-wrapper {
-    transform: translateX(-80%);
-  }
-}
 
 :root {
   --background: #ffffff;
@@ -216,5 +204,30 @@ body {
   .listItem {
     margin-top: 9px;
     margin-bottom: 9px;
+  }
+
+  #page-wrapper {
+    background-color: white;
+    position: relative;
+    transition: transform 0.3s ease-in-out;
+    z-index: 30;
+  }
+
+  /* Mobile menu - slide page left to reveal menu */
+  @media (max-width: 767px) {
+    /* Hide menu off-screen initially */
+    .mobile-menu-drawer {
+      transform: translateX(100%);
+      transition: transform 0.3s ease-in-out;
+    }
+
+    /* When menu is open, slide page left and show menu */
+    body.mobile-menu-open #page-wrapper {
+      transform: translateX(-80%);
+    }
+
+    body.mobile-menu-open .mobile-menu-drawer {
+      transform: translateX(0);
+    }
   }
 }

--- a/components/header/MobileMenuButton.tsx
+++ b/components/header/MobileMenuButton.tsx
@@ -1,0 +1,35 @@
+"use client";
+import { useMobileMenu } from "./MobileMenuContext";
+
+export default function MobileMenuButton() {
+  const { isMobileMenuOpen, setIsMobileMenuOpen } = useMobileMenu();
+
+  return (
+    <button
+      className="md:hidden flex items-center justify-center w-10 h-10"
+      onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+      aria-label={isMobileMenuOpen ? "Close menu" : "Open menu"}
+    >
+      <div className="w-6 h-5 relative flex flex-col justify-center gap-1.5">
+        {/* Top bar */}
+        <span
+          className={`block h-0.5 w-full bg-main-darkpurple transition-all duration-300 ease-in-out ${
+            isMobileMenuOpen ? "rotate-45 translate-y-2" : ""
+          }`}
+        />
+        {/* Middle bar */}
+        <span
+          className={`block h-0.5 w-full bg-main-darkpurple transition-all duration-300 ease-in-out ${
+            isMobileMenuOpen ? "opacity-0" : ""
+          }`}
+        />
+        {/* Bottom bar */}
+        <span
+          className={`block h-0.5 w-full bg-main-darkpurple transition-all duration-300 ease-in-out ${
+            isMobileMenuOpen ? "-rotate-45 -translate-y-2" : ""
+          }`}
+        />
+      </div>
+    </button>
+  );
+}

--- a/components/header/MobileMenuContext.tsx
+++ b/components/header/MobileMenuContext.tsx
@@ -12,7 +12,11 @@ const MobileMenuContext = createContext<MobileMenuContextType | undefined>(
   undefined,
 );
 
-export function MobileMenuProvider({ children }: { children: React.ReactNode }) {
+export function MobileMenuProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState<boolean>(false);
   const [expandedSections, setExpandedSections] = useState<{
     [key: string]: boolean;

--- a/components/header/MobileMenuContext.tsx
+++ b/components/header/MobileMenuContext.tsx
@@ -1,0 +1,57 @@
+"use client";
+import { createContext, useContext, useState, useEffect } from "react";
+
+interface MobileMenuContextType {
+  isMobileMenuOpen: boolean;
+  setIsMobileMenuOpen: (open: boolean) => void;
+  expandedSections: { [key: string]: boolean };
+  setExpandedSections: (sections: { [key: string]: boolean }) => void;
+}
+
+const MobileMenuContext = createContext<MobileMenuContextType | undefined>(
+  undefined,
+);
+
+export function MobileMenuProvider({ children }: { children: React.ReactNode }) {
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState<boolean>(false);
+  const [expandedSections, setExpandedSections] = useState<{
+    [key: string]: boolean;
+  }>({});
+
+  // Add/remove body class when mobile menu opens/closes
+  useEffect(() => {
+    if (isMobileMenuOpen) {
+      document.body.style.overflow = "hidden";
+      document.body.classList.add("mobile-menu-open");
+    } else {
+      document.body.style.overflow = "";
+      document.body.classList.remove("mobile-menu-open");
+    }
+
+    return () => {
+      document.body.style.overflow = "";
+      document.body.classList.remove("mobile-menu-open");
+    };
+  }, [isMobileMenuOpen]);
+
+  return (
+    <MobileMenuContext.Provider
+      value={{
+        isMobileMenuOpen,
+        setIsMobileMenuOpen,
+        expandedSections,
+        setExpandedSections,
+      }}
+    >
+      {children}
+    </MobileMenuContext.Provider>
+  );
+}
+
+export function useMobileMenu() {
+  const context = useContext(MobileMenuContext);
+  if (context === undefined) {
+    throw new Error("useMobileMenu must be used within a MobileMenuProvider");
+  }
+  return context;
+}

--- a/components/header/MobileMenuDrawer.tsx
+++ b/components/header/MobileMenuDrawer.tsx
@@ -1,0 +1,267 @@
+"use client";
+import { useMobileMenu } from "./MobileMenuContext";
+import YellowAccentButton from "../accentButton/yellowAccentButton";
+
+export default function MobileMenuDrawer() {
+  const { isMobileMenuOpen, setIsMobileMenuOpen, expandedSections, setExpandedSections } = useMobileMenu();
+
+  return (
+    <div className="mobile-menu-drawer fixed top-0 right-0 h-screen w-4/5 bg-white z-20 md:hidden">
+      <div className="relative flex flex-col h-full overflow-y-auto">
+        {/* Mobile navigation links */}
+        <nav className="flex flex-col w-full px-8 pt-20 pb-6 space-y-1">
+          {/* About - expandable */}
+          <div className="w-full">
+            <button
+              onClick={() =>
+                setExpandedSections({
+                  ...expandedSections,
+                  about: !expandedSections.about,
+                })
+              }
+              className="flex items-center justify-start w-full text-left text-h3 text-header-purple py-3 font-normal"
+            >
+              <span className="mr-2 text-base">+</span>
+              <span>About</span>
+            </button>
+            {expandedSections.about && (
+              <div className="pl-8 space-y-1 pb-2">
+                <a
+                  href="/about-us?page=About Us"
+                  className="block text-body text-secondary-grey py-2"
+                  onClick={() => setIsMobileMenuOpen(false)}
+                >
+                  About Us
+                </a>
+                <a
+                  href="/about-us?page=Our Families"
+                  className="block text-body text-secondary-grey py-2"
+                  onClick={() => setIsMobileMenuOpen(false)}
+                >
+                  Our Families
+                </a>
+                <a
+                  href="/about-us?page=Our News"
+                  className="block text-body text-secondary-grey py-2"
+                  onClick={() => setIsMobileMenuOpen(false)}
+                >
+                  Our News
+                </a>
+                <a
+                  href="/about-us?page=Our Team"
+                  className="block text-body text-secondary-grey py-2"
+                  onClick={() => setIsMobileMenuOpen(false)}
+                >
+                  Our Team
+                </a>
+                <a
+                  href="/about-us?page=Report of hope"
+                  className="block text-body text-secondary-grey py-2"
+                  onClick={() => setIsMobileMenuOpen(false)}
+                >
+                  Report of Hope
+                </a>
+                <a
+                  href="/about-us?page=Careers"
+                  className="block text-body text-secondary-grey py-2"
+                  onClick={() => setIsMobileMenuOpen(false)}
+                >
+                  Careers
+                </a>
+              </div>
+            )}
+          </div>
+
+          {/* Need Support - simple link */}
+          <a
+            href="/support"
+            className="block w-full text-h3 text-header-purple py-3 font-normal"
+            onClick={() => setIsMobileMenuOpen(false)}
+          >
+            Need Support?
+          </a>
+
+          {/* For Families - expandable */}
+          <div className="w-full">
+            <button
+              onClick={() =>
+                setExpandedSections({
+                  ...expandedSections,
+                  families: !expandedSections.families,
+                })
+              }
+              className="flex items-center justify-start w-full text-left text-h3 text-header-purple py-3 font-normal"
+            >
+              <span className="mr-2 text-base">+</span>
+              <span>For Families</span>
+            </button>
+            {expandedSections.families && (
+              <div className="pl-8 space-y-1 pb-2">
+                <a
+                  href="/for-families?page=Here for You"
+                  className="block text-body text-secondary-grey py-2"
+                  onClick={() => setIsMobileMenuOpen(false)}
+                >
+                  Here for You
+                </a>
+                <a
+                  href="/for-families?page=Financial Support"
+                  className="block text-body text-secondary-grey py-2"
+                  onClick={() => setIsMobileMenuOpen(false)}
+                >
+                  Financial Support
+                </a>
+                <a
+                  href="/for-families?page=Emotional Support"
+                  className="block text-body text-secondary-grey py-2"
+                  onClick={() => setIsMobileMenuOpen(false)}
+                >
+                  Emotional Support
+                </a>
+                <a
+                  href="/for-families?page=Social Support"
+                  className="block text-body text-secondary-grey py-2"
+                  onClick={() => setIsMobileMenuOpen(false)}
+                >
+                  Social Support
+                </a>
+                <a
+                  href="/for-families?page=Research Support"
+                  className="block text-body text-secondary-grey py-2"
+                  onClick={() => setIsMobileMenuOpen(false)}
+                >
+                  Research Support
+                </a>
+                <a
+                  href="/for-families?page=Upcoming Family Events"
+                  className="block text-body text-secondary-grey py-2"
+                  onClick={() => setIsMobileMenuOpen(false)}
+                >
+                  Upcoming Family Events
+                </a>
+                <a
+                  href={`/for-families?page=${encodeURIComponent("Q&A")}`}
+                  className="block text-body text-secondary-grey py-2"
+                  onClick={() => setIsMobileMenuOpen(false)}
+                >
+                  Q&A
+                </a>
+              </div>
+            )}
+          </div>
+
+          {/* How to Help - expandable */}
+          <div className="w-full">
+            <button
+              onClick={() =>
+                setExpandedSections({
+                  ...expandedSections,
+                  help: !expandedSections.help,
+                })
+              }
+              className="flex items-center justify-start w-full text-left text-h3 text-header-purple py-3 font-normal"
+            >
+              <span className="mr-2 text-base">+</span>
+              <span>How to Help</span>
+            </button>
+            {expandedSections.help && (
+              <div className="pl-8 space-y-1 pb-2">
+                <a
+                  href="/how-to-help?page=Ways to Give"
+                  className="block text-body text-secondary-grey py-2"
+                  onClick={() => setIsMobileMenuOpen(false)}
+                >
+                  Ways to Give
+                </a>
+                <a
+                  href="/how-to-help?page=PJ Day"
+                  className="block text-body text-secondary-grey py-2"
+                  onClick={() => setIsMobileMenuOpen(false)}
+                >
+                  PJ Day
+                </a>
+                <a
+                  href="/how-to-help?page=Gold"
+                  className="block text-body text-secondary-grey py-2"
+                  onClick={() => setIsMobileMenuOpen(false)}
+                >
+                  Gold
+                </a>
+                <a
+                  href="/how-to-help?page=Host an Event"
+                  className="block text-body text-secondary-grey py-2"
+                  onClick={() => setIsMobileMenuOpen(false)}
+                >
+                  Host an Event
+                </a>
+                <a
+                  href="/how-to-help?page=Marketplace"
+                  className="block text-body text-secondary-grey py-2"
+                  onClick={() => setIsMobileMenuOpen(false)}
+                >
+                  Marketplace
+                </a>
+                <a
+                  href="/how-to-help?page=Merchandise"
+                  className="block text-body text-secondary-grey py-2"
+                  onClick={() => setIsMobileMenuOpen(false)}
+                >
+                  Merchandise
+                </a>
+                <a
+                  href="/how-to-help?page=Volunteer"
+                  className="block text-body text-secondary-grey py-2"
+                  onClick={() => setIsMobileMenuOpen(false)}
+                >
+                  Volunteer
+                </a>
+                <a
+                  href="/how-to-help?page=Our Supporters"
+                  className="block text-body text-secondary-grey py-2"
+                  onClick={() => setIsMobileMenuOpen(false)}
+                >
+                  Our Supporters
+                </a>
+              </div>
+            )}
+          </div>
+
+          {/* Simple links */}
+          <a
+            href="/events"
+            className="block w-full text-h3 text-header-purple py-3 font-normal"
+            onClick={() => setIsMobileMenuOpen(false)}
+          >
+            Events
+          </a>
+          <a
+            href="/dip"
+            className="block w-full text-h3 text-header-purple py-3 font-normal"
+            onClick={() => setIsMobileMenuOpen(false)}
+          >
+            Dip
+          </a>
+          <a
+            href="/hands-of-hope"
+            className="block w-full text-h3 text-header-purple py-3 font-normal"
+            onClick={() => setIsMobileMenuOpen(false)}
+          >
+            Hands of Hope
+          </a>
+          <a
+            href="/contact"
+            className="block w-full text-h3 text-header-purple py-3 font-normal"
+            onClick={() => setIsMobileMenuOpen(false)}
+          >
+            Contact
+          </a>
+
+          {/* Donate button */}
+          <div className="pt-10 pb-4 w-full flex justify-center">
+            <YellowAccentButton>Donate</YellowAccentButton>
+          </div>
+        </nav>
+      </div>
+    </div>
+  );
+}

--- a/components/header/MobileMenuDrawer.tsx
+++ b/components/header/MobileMenuDrawer.tsx
@@ -3,7 +3,12 @@ import { useMobileMenu } from "./MobileMenuContext";
 import YellowAccentButton from "../accentButton/yellowAccentButton";
 
 export default function MobileMenuDrawer() {
-  const { isMobileMenuOpen, setIsMobileMenuOpen, expandedSections, setExpandedSections } = useMobileMenu();
+  const {
+    isMobileMenuOpen,
+    setIsMobileMenuOpen,
+    expandedSections,
+    setExpandedSections,
+  } = useMobileMenu();
 
   return (
     <div className="mobile-menu-drawer fixed top-0 right-0 h-screen w-4/5 bg-white z-20 md:hidden">

--- a/components/header/header.tsx
+++ b/components/header/header.tsx
@@ -38,7 +38,6 @@ function Header() {
     };
   }, []);
 
-
   const getHeaderAnimation = () => {
     // scrollY is below 100 (top of page)
     if (!isSticky && !wasSticky) return "relative";
@@ -54,105 +53,105 @@ function Header() {
     <div
       className={`bg-white transition-transform duration-300 top-0 flex flex-row justify-between items-center px-4 w-full h-auto py-2 md:h-22 z-30 md:z-60 fixed md:${getHeaderAnimation()}`}
     >
-        <div className="w-full flex flex-row justify-between items-center bg-white">
-          <a href="/" className="flex items-center">
-            <Image
-              className="h-18.5 w-auto"
-              alt="Childcan Logo"
-              height={110}
-              width={210}
-              src={"/images/Childcan-Logo.png.webp"}
-              priority
-            ></Image>
-          </a>
+      <div className="w-full flex flex-row justify-between items-center bg-white">
+        <a href="/" className="flex items-center">
+          <Image
+            className="h-18.5 w-auto"
+            alt="Childcan Logo"
+            height={110}
+            width={210}
+            src={"/images/Childcan-Logo.png.webp"}
+            priority
+          ></Image>
+        </a>
 
-          {/* Mobile menu button */}
-          <MobileMenuButton />
+        {/* Mobile menu button */}
+        <MobileMenuButton />
 
-          {/* Desktop navigation - hidden on mobile */}
-          <nav className="hidden md:flex flex-row items-center">
-            <HeaderLink
-              title="About"
-              link="/about-us"
-              items={[
-                { link: "about-us?page=About Us", label: "About Us" },
-                { link: "about-us?page=Our Families", label: "Our Families" },
-                { link: "about-us?page=Our News", label: "Our News" },
-                { link: "about-us?page=Our Team", label: "Our Team" },
-                {
-                  link: "about-us?page=Report of hope",
-                  label: "Report of Hope",
-                },
-                { link: "about-us?page=Careers", label: "Careers" },
-              ]}
-            ></HeaderLink>
-            <HeaderLink link="/support" title="Need Support?"></HeaderLink>
-            <HeaderLink
-              link="/for-families"
-              title="For Families"
-              items={[
-                {
-                  link: "for-families?page=Here for You",
-                  label: "Here for You",
-                },
-                {
-                  link: "for-families?page=Financial Support",
-                  label: "Financial Support",
-                },
-                {
-                  link: "for-families?page=Emotional Support",
-                  label: "Emotional Support",
-                },
-                {
-                  link: "for-families?page=Social Support",
-                  label: "Social Support",
-                },
-                {
-                  link: "for-families?page=Research Support",
-                  label: "Research Support",
-                },
-                {
-                  link: "for-families?page=Upcoming Family Events",
-                  label: "Upcoming Family Events",
-                },
-                {
-                  link: `for-families?page=${encodeURIComponent("Q&A")}`,
-                  label: "Q&A",
-                },
-              ]}
-            ></HeaderLink>
-            <HeaderLink
-              title="How to Help"
-              link="how-to-help"
-              items={[
-                {
-                  link: "/how-to-help?page=Ways to Give",
-                  label: "Ways to Give",
-                },
-                { link: "/how-to-help?page=PJ Day", label: "PJ Day" },
-                { link: "/how-to-help?page=Gold", label: "Gold" },
-                {
-                  link: "/how-to-help?page=Host an Event",
-                  label: "Host an Event",
-                },
-                { link: "/how-to-help?page=Marketplace", label: "Marketplace" },
-                { link: "/how-to-help?page=Merchandise", label: "Merchandise" },
-                { link: "/how-to-help?page=Volunteer", label: "Volunteer" },
-                {
-                  link: "/how-to-help?page=Our Supporters",
-                  label: "Our Supporters",
-                },
-              ]}
-            ></HeaderLink>
-            <HeaderLink link="" title="Events"></HeaderLink>
-            <HeaderLink link="" title="Star"></HeaderLink>
-            <HeaderLink link="" title="Hands of Hope"></HeaderLink>
-            <HeaderLink link="/contact" title="Contact"></HeaderLink>
-            <YellowAccentButton className="ml-8">Donate</YellowAccentButton>
-          </nav>
-        </div>
+        {/* Desktop navigation - hidden on mobile */}
+        <nav className="hidden md:flex flex-row items-center">
+          <HeaderLink
+            title="About"
+            link="/about-us"
+            items={[
+              { link: "about-us?page=About Us", label: "About Us" },
+              { link: "about-us?page=Our Families", label: "Our Families" },
+              { link: "about-us?page=Our News", label: "Our News" },
+              { link: "about-us?page=Our Team", label: "Our Team" },
+              {
+                link: "about-us?page=Report of hope",
+                label: "Report of Hope",
+              },
+              { link: "about-us?page=Careers", label: "Careers" },
+            ]}
+          ></HeaderLink>
+          <HeaderLink link="/support" title="Need Support?"></HeaderLink>
+          <HeaderLink
+            link="/for-families"
+            title="For Families"
+            items={[
+              {
+                link: "for-families?page=Here for You",
+                label: "Here for You",
+              },
+              {
+                link: "for-families?page=Financial Support",
+                label: "Financial Support",
+              },
+              {
+                link: "for-families?page=Emotional Support",
+                label: "Emotional Support",
+              },
+              {
+                link: "for-families?page=Social Support",
+                label: "Social Support",
+              },
+              {
+                link: "for-families?page=Research Support",
+                label: "Research Support",
+              },
+              {
+                link: "for-families?page=Upcoming Family Events",
+                label: "Upcoming Family Events",
+              },
+              {
+                link: `for-families?page=${encodeURIComponent("Q&A")}`,
+                label: "Q&A",
+              },
+            ]}
+          ></HeaderLink>
+          <HeaderLink
+            title="How to Help"
+            link="how-to-help"
+            items={[
+              {
+                link: "/how-to-help?page=Ways to Give",
+                label: "Ways to Give",
+              },
+              { link: "/how-to-help?page=PJ Day", label: "PJ Day" },
+              { link: "/how-to-help?page=Gold", label: "Gold" },
+              {
+                link: "/how-to-help?page=Host an Event",
+                label: "Host an Event",
+              },
+              { link: "/how-to-help?page=Marketplace", label: "Marketplace" },
+              { link: "/how-to-help?page=Merchandise", label: "Merchandise" },
+              { link: "/how-to-help?page=Volunteer", label: "Volunteer" },
+              {
+                link: "/how-to-help?page=Our Supporters",
+                label: "Our Supporters",
+              },
+            ]}
+          ></HeaderLink>
+          <HeaderLink link="" title="Events"></HeaderLink>
+          <HeaderLink link="" title="Star"></HeaderLink>
+          <HeaderLink link="" title="Hands of Hope"></HeaderLink>
+          <HeaderLink link="/contact" title="Contact"></HeaderLink>
+          <YellowAccentButton className="ml-8">Donate</YellowAccentButton>
+        </nav>
       </div>
-    );
+    </div>
+  );
 }
 
 export default Header;

--- a/components/header/header.tsx
+++ b/components/header/header.tsx
@@ -3,14 +3,11 @@ import { useState, useEffect } from "react";
 import Image from "next/image";
 import HeaderLink from "./headerLink";
 import YellowAccentButton from "../accentButton/yellowAccentButton";
+import MobileMenuButton from "./MobileMenuButton";
 
 function Header() {
   const [isSticky, setIsSticky] = useState<boolean>(false);
   const [wasSticky, setWasSticky] = useState<boolean>(false);
-  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState<boolean>(false);
-  const [expandedSections, setExpandedSections] = useState<{
-    [key: string]: boolean;
-  }>({});
 
   useEffect(() => {
     // let scrollDebounce: NodeJS.Timeout | undefined; // debounce timer
@@ -41,21 +38,6 @@ function Header() {
     };
   }, []);
 
-  // Add class to body when mobile menu is open for slide effect
-  useEffect(() => {
-    if (isMobileMenuOpen) {
-      document.body.style.overflow = "hidden";
-      document.body.classList.add("mobile-menu-open");
-    } else {
-      document.body.style.overflow = "";
-      document.body.classList.remove("mobile-menu-open");
-    }
-
-    return () => {
-      document.body.style.overflow = "";
-      document.body.classList.remove("mobile-menu-open");
-    };
-  }, [isMobileMenuOpen]);
 
   const getHeaderAnimation = () => {
     // scrollY is below 100 (top of page)
@@ -69,10 +51,9 @@ function Header() {
   };
 
   return (
-    <>
-      <div
-        className={`bg-white transition-transform duration-300 top-0 flex flex-row justify-between items-center px-4 w-full h-auto py-2 md:h-22 z-40 ${getHeaderAnimation()}`}
-      >
+    <div
+      className={`bg-white transition-transform duration-300 top-0 flex flex-row justify-between items-center px-4 w-full h-auto py-2 md:h-22 z-30 md:z-60 fixed md:${getHeaderAnimation()}`}
+    >
         <div className="w-full flex flex-row justify-between items-center bg-white">
           <a href="/" className="flex items-center">
             <Image
@@ -85,30 +66,8 @@ function Header() {
             ></Image>
           </a>
 
-          {/* Hamburger menu button - visible on mobile only */}
-          <button
-            className="md:hidden flex items-center relative w-8 h-8"
-            onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-            aria-label="Toggle menu"
-          >
-            <div className="w-6 h-5 relative flex flex-col justify-between">
-              <span
-                className={`block h-0.5 w-full bg-main-darkpurple transition-all duration-300 ease-in-out ${
-                  isMobileMenuOpen ? "rotate-45 translate-y-2.25" : ""
-                }`}
-              />
-              <span
-                className={`block h-0.5 w-full bg-main-darkpurple transition-all duration-300 ease-in-out ${
-                  isMobileMenuOpen ? "opacity-0" : "opacity-100"
-                }`}
-              />
-              <span
-                className={`block h-0.5 w-full bg-main-darkpurple transition-all duration-300 ease-in-out ${
-                  isMobileMenuOpen ? "-rotate-45 -translate-y-2.25" : ""
-                }`}
-              />
-            </div>
-          </button>
+          {/* Mobile menu button */}
+          <MobileMenuButton />
 
           {/* Desktop navigation - hidden on mobile */}
           <nav className="hidden md:flex flex-row items-center">
@@ -193,267 +152,7 @@ function Header() {
           </nav>
         </div>
       </div>
-
-      {/* Mobile menu drawer */}
-      <div className="absolute top-0 right-0 h-screen w-4/5 max-w-sm bg-white shadow-2xl z-50 md:hidden translate-x-full">
-        <div className="flex flex-col h-full overflow-y-auto items-center pt-20">
-          {/* Mobile navigation links */}
-          <nav className="flex flex-col w-full px-12 pb-6 space-y-1 items-center">
-            {/* About - expandable */}
-            <div className="w-full">
-              <button
-                onClick={() =>
-                  setExpandedSections({
-                    ...expandedSections,
-                    about: !expandedSections.about,
-                  })
-                }
-                className="flex items-center justify-start w-full text-left text-h3 text-header-purple py-3 font-normal"
-              >
-                <span className="mr-2 text-base">+</span>
-                <span>About</span>
-              </button>
-              {expandedSections.about && (
-                <div className="pl-8 space-y-1 pb-2">
-                  <a
-                    href="/about-us?page=About Us"
-                    className="block text-body text-secondary-grey py-2"
-                    onClick={() => setIsMobileMenuOpen(false)}
-                  >
-                    About Us
-                  </a>
-                  <a
-                    href="/about-us?page=Our Families"
-                    className="block text-body text-secondary-grey py-2"
-                    onClick={() => setIsMobileMenuOpen(false)}
-                  >
-                    Our Families
-                  </a>
-                  <a
-                    href="/about-us?page=Our News"
-                    className="block text-body text-secondary-grey py-2"
-                    onClick={() => setIsMobileMenuOpen(false)}
-                  >
-                    Our News
-                  </a>
-                  <a
-                    href="/about-us?page=Our Team"
-                    className="block text-body text-secondary-grey py-2"
-                    onClick={() => setIsMobileMenuOpen(false)}
-                  >
-                    Our Team
-                  </a>
-                  <a
-                    href="/about-us?page=Report of hope"
-                    className="block text-body text-secondary-grey py-2"
-                    onClick={() => setIsMobileMenuOpen(false)}
-                  >
-                    Report of Hope
-                  </a>
-                  <a
-                    href="/about-us?page=Careers"
-                    className="block text-body text-secondary-grey py-2"
-                    onClick={() => setIsMobileMenuOpen(false)}
-                  >
-                    Careers
-                  </a>
-                </div>
-              )}
-            </div>
-
-            {/* Need Support - simple link */}
-            <a
-              href="/support"
-              className="block w-full text-h3 text-header-purple py-3 font-normal"
-              onClick={() => setIsMobileMenuOpen(false)}
-            >
-              Need Support?
-            </a>
-
-            {/* For Families - expandable */}
-            <div className="w-full">
-              <button
-                onClick={() =>
-                  setExpandedSections({
-                    ...expandedSections,
-                    families: !expandedSections.families,
-                  })
-                }
-                className="flex items-center justify-start w-full text-left text-h3 text-header-purple py-3 font-normal"
-              >
-                <span className="mr-2 text-base">+</span>
-                <span>For Families</span>
-              </button>
-              {expandedSections.families && (
-                <div className="pl-8 space-y-1 pb-2">
-                  <a
-                    href="/for-families?page=Here for You"
-                    className="block text-body text-secondary-grey py-2"
-                    onClick={() => setIsMobileMenuOpen(false)}
-                  >
-                    Here for You
-                  </a>
-                  <a
-                    href="/for-families?page=Financial Support"
-                    className="block text-body text-secondary-grey py-2"
-                    onClick={() => setIsMobileMenuOpen(false)}
-                  >
-                    Financial Support
-                  </a>
-                  <a
-                    href="/for-families?page=Emotional Support"
-                    className="block text-body text-secondary-grey py-2"
-                    onClick={() => setIsMobileMenuOpen(false)}
-                  >
-                    Emotional Support
-                  </a>
-                  <a
-                    href="/for-families?page=Social Support"
-                    className="block text-body text-secondary-grey py-2"
-                    onClick={() => setIsMobileMenuOpen(false)}
-                  >
-                    Social Support
-                  </a>
-                  <a
-                    href="/for-families?page=Research Support"
-                    className="block text-body text-secondary-grey py-2"
-                    onClick={() => setIsMobileMenuOpen(false)}
-                  >
-                    Research Support
-                  </a>
-                  <a
-                    href="/for-families?page=Upcoming Family Events"
-                    className="block text-body text-secondary-grey py-2"
-                    onClick={() => setIsMobileMenuOpen(false)}
-                  >
-                    Upcoming Family Events
-                  </a>
-                  <a
-                    href={`/for-families?page=${encodeURIComponent("Q&A")}`}
-                    className="block text-body text-secondary-grey py-2"
-                    onClick={() => setIsMobileMenuOpen(false)}
-                  >
-                    Q&A
-                  </a>
-                </div>
-              )}
-            </div>
-
-            {/* How to Help - expandable */}
-            <div className="w-full">
-              <button
-                onClick={() =>
-                  setExpandedSections({
-                    ...expandedSections,
-                    help: !expandedSections.help,
-                  })
-                }
-                className="flex items-center justify-start w-full text-left text-h3 text-header-purple py-3 font-normal"
-              >
-                <span className="mr-2 text-base">+</span>
-                <span>How to Help</span>
-              </button>
-              {expandedSections.help && (
-                <div className="pl-8 space-y-1 pb-2">
-                  <a
-                    href="/how-to-help?page=Ways to Give"
-                    className="block text-body text-secondary-grey py-2"
-                    onClick={() => setIsMobileMenuOpen(false)}
-                  >
-                    Ways to Give
-                  </a>
-                  <a
-                    href="/how-to-help?page=PJ Day"
-                    className="block text-body text-secondary-grey py-2"
-                    onClick={() => setIsMobileMenuOpen(false)}
-                  >
-                    PJ Day
-                  </a>
-                  <a
-                    href="/how-to-help?page=Gold"
-                    className="block text-body text-secondary-grey py-2"
-                    onClick={() => setIsMobileMenuOpen(false)}
-                  >
-                    Gold
-                  </a>
-                  <a
-                    href="/how-to-help?page=Host an Event"
-                    className="block text-body text-secondary-grey py-2"
-                    onClick={() => setIsMobileMenuOpen(false)}
-                  >
-                    Host an Event
-                  </a>
-                  <a
-                    href="/how-to-help?page=Marketplace"
-                    className="block text-body text-secondary-grey py-2"
-                    onClick={() => setIsMobileMenuOpen(false)}
-                  >
-                    Marketplace
-                  </a>
-                  <a
-                    href="/how-to-help?page=Merchandise"
-                    className="block text-body text-secondary-grey py-2"
-                    onClick={() => setIsMobileMenuOpen(false)}
-                  >
-                    Merchandise
-                  </a>
-                  <a
-                    href="/how-to-help?page=Volunteer"
-                    className="block text-body text-secondary-grey py-2"
-                    onClick={() => setIsMobileMenuOpen(false)}
-                  >
-                    Volunteer
-                  </a>
-                  <a
-                    href="/how-to-help?page=Our Supporters"
-                    className="block text-body text-secondary-grey py-2"
-                    onClick={() => setIsMobileMenuOpen(false)}
-                  >
-                    Our Supporters
-                  </a>
-                </div>
-              )}
-            </div>
-
-            {/* Simple links */}
-            <a
-              href="/events"
-              className="block w-full text-h3 text-header-purple py-3 font-normal"
-              onClick={() => setIsMobileMenuOpen(false)}
-            >
-              Events
-            </a>
-            <a
-              href="/dip"
-              className="block w-full text-h3 text-header-purple py-3 font-normal"
-              onClick={() => setIsMobileMenuOpen(false)}
-            >
-              Dip
-            </a>
-            <a
-              href="/hands-of-hope"
-              className="block w-full text-h3 text-header-purple py-3 font-normal"
-              onClick={() => setIsMobileMenuOpen(false)}
-            >
-              Hands of Hope
-            </a>
-            <a
-              href="/contact"
-              className="block w-full text-h3 text-header-purple py-3 font-normal"
-              onClick={() => setIsMobileMenuOpen(false)}
-            >
-              Contact
-            </a>
-
-            {/* Donate button */}
-            <div className="pt-10 pb-4 w-full flex justify-center">
-              <YellowAccentButton>Donate</YellowAccentButton>
-            </div>
-          </nav>
-        </div>
-      </div>
-    </>
-  );
+    );
 }
 
 export default Header;


### PR DESCRIPTION
## Summary
Implemented a sliding page effect for the mobile menu to match the childcan.com reference behavior, where the entire page slides left to reveal the menu from behind.

## Changes Made

### New Components
- **MobileMenuContext**: Shared state management for menu open/close state and expanded sections
- **MobileMenuDrawer**: Standalone menu drawer component that renders outside page-wrapper
- **MobileMenuButton**: Animated hamburger-to-X button component with smooth transitions

### Modified Files
- **app/globals.css**: Moved mobile menu CSS into `@layer components` for Tailwind v4 compatibility, added page slide animation
- **app/(main-route)/layout.tsx**: Restructured to render menu drawer outside page-wrapper, wrapped with MobileMenuProvider
- **components/header/header.tsx**: Removed mobile menu drawer and state management, integrated MobileMenuButton
- **app/(main-route)/events/EventCard.tsx**: Made responsive for mobile viewports (stacks vertically)

## Behavior
- ✅ Menu button (hamburger) is in the header and slides with the page
- ✅ Hamburger smoothly animates into an X when menu opens
- ✅ Entire page (including header) slides 80% to the left when menu opens
- ✅ Menu drawer is revealed from behind at fixed position on the right
- ✅ Clicking X or any menu item closes the menu and slides page back
- ✅ Desktop view remains unaffected

## Test Plan
- [x] Test mobile menu open/close functionality
- [x] Verify hamburger-to-X animation is smooth
- [x] Confirm page slides left when menu opens
- [x] Ensure menu is hidden when closed
- [x] Check that menu button stays in header
- [x] Verify desktop navigation is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)